### PR TITLE
Incoming request metrics

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,0 +1,31 @@
+"use strict";
+
+const client = require("prom-client");
+
+const httpIncomingRequestsTotal = new client.Counter({
+  name: "lu_http_incoming_requests_total",
+  help: "Total number of incoming http requests.",
+  labelNames: ["appName"]
+});
+const httpIncomingRequestsInProgress = new client.Gauge({
+  name: "lu_http_incoming_requests_in_progress",
+  help: "Number of incoming requests currently processing.",
+  labelNames: ["appName"]
+});
+const httpIncomingRequestDurationSeconds = new client.Histogram({
+  name: "lu_http_incoming_request_duration_seconds",
+  help: "Duration of all incoming http requests.",
+  labelNames: ["appName"]
+});
+const httpIncomingRequestErrorsTotal = new client.Counter({
+  name: "lu_http_incoming_request_errors_total",
+  help: "Number of incoming requests that responds with error.",
+  labelNames: ["appName", "statusCode"]
+});
+
+module.exports = {
+  httpIncomingRequestsTotal,
+  httpIncomingRequestsInProgress,
+  httpIncomingRequestDurationSeconds,
+  httpIncomingRequestErrorsTotal
+};

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -5,6 +5,7 @@ const config = require("exp-config");
 const {logger} = require("lu-logger");
 const {correlationLog, debugMeta} = require("./log-middleware");
 const isHealthOrMetricRequest = require("./is-health-or-metric-request");
+const requestMetrics = require("./request-metrics");
 
 function accessLog(req, res, next) {
   const time = new Date();
@@ -31,6 +32,7 @@ function accessLog(req, res, next) {
 const router = express.Router(); // eslint-disable-line new-cap
 router.use(correlationLog);
 router.use(debugMeta);
+router.use(requestMetrics);
 if (config.requestLogging) {
   router.use(accessLog);
 }

--- a/lib/request-metrics.js
+++ b/lib/request-metrics.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const metrics = require("./metrics");
+const statusCodeRegex = /^[^2-3]/g;
+const callingAppName = require(`${process.cwd()}/package.json`).name;
+
+module.exports = requestMetrics;
+
+const ignoredPaths = ["_alive", "_status", "metrics"];
+
+function requestMetrics(req, res, next) {
+  if (ignored(req.path)) return next();
+
+  const appName = getAppName();
+
+  const observeRequestDuration = metrics.httpIncomingRequestDurationSeconds.startTimer({appName});
+  metrics.httpIncomingRequestsTotal.inc({appName});
+  metrics.httpIncomingRequestsInProgress.inc({appName});
+
+  let alreadyReported = false;
+
+  const report = (requestFailed) => {
+    if (alreadyReported) return;
+
+    observeRequestDuration({appName});
+    metrics.httpIncomingRequestsInProgress.dec({appName});
+
+    if (requestFailed) {
+      metrics.httpIncomingRequestErrorsTotal.inc({appName, statusCode: res.statusCode});
+    }
+
+    alreadyReported = true;
+  };
+
+  res.on("close", () => {
+    // this would indicate an error
+    report(true);
+  });
+
+  res.on("finish", () => {
+    const requestFailed = statusCodeRegex.test(res.statusCode.toString());
+    report(requestFailed);
+  });
+
+  next();
+}
+
+function ignored(reqPath) {
+  const reqPathFirstPart = reqPath.split("/")[1];
+  if (ignoredPaths.some((path) => reqPathFirstPart === path)) {
+    return true;
+  }
+  return false;
+}
+
+function getAppName() {
+  return callingAppName && callingAppName.replace(/^@[^/]*\//, "").replace(/-/g, "");
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lu-server",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Base server for lu services",
   "main": "index.js",
   "repository": "https://github.com/bonniernews/lu-server",

--- a/test/feature/request-metrics-feature.js
+++ b/test/feature/request-metrics-feature.js
@@ -1,0 +1,94 @@
+"use strict";
+
+const expect = require("chai").expect;
+const prometeheus = require("../../lib/prometheus");
+const {get} = require("../helpers/request-helper");
+
+Feature("Incoming request metrics", () => {
+  // eslint-disable-next-line no-undef
+  beforeEachScenario(prometeheus.clear);
+
+  Scenario("Request metrics should be registered", () => {
+    let metricsRes;
+    When("requesting the /metrics endpoint", async () => {
+      metricsRes = await get("/metrics");
+    });
+    Then("the incoming request metrics should be registered", () => {
+      const metrics = metricsRes.text.split("\n").reduce((acc, row) => {
+        if (row.startsWith("# TYPE")) {
+          const vals = row.split(" ");
+          acc[vals[2]] = vals[3];
+        }
+        return acc;
+      }, {});
+      metrics.should.have.property("lu_http_incoming_requests_total", "counter");
+      metrics.should.have.property("lu_http_incoming_requests_in_progress", "gauge");
+      metrics.should.have.property("lu_http_incoming_request_duration_seconds", "histogram");
+      metrics.should.have.property("lu_http_incoming_request_errors_total", "counter");
+    });
+  });
+
+  Scenario("successfull request should generate metric", () => {
+    let metricsRes;
+    Given("a request is made to an epic endpoint", async () => {
+      const router = require("../../lib/routes");
+      router.get("/epic-endpoint", (req, res) => {
+        res.sendStatus(200).json({});
+      });
+      await get("/epic-endpoint");
+    });
+    When("requesting the /metrics endpoint", async () => {
+      metricsRes = await get("/metrics");
+    });
+    Then("the incoming request total counter should be incremented", () => {
+      const totalCounter = getCounterMetric(metricsRes, "lu_http_incoming_request_duration_seconds");
+      totalCounter.count.should.eql("1");
+      totalCounter.labels.should.include("appName");
+    });
+    And("the incoming request duration counter should be incremented", () => {
+      const totalCounter = getCounterMetric(metricsRes, "lu_http_incoming_request_duration_seconds");
+      totalCounter.count.should.eql("1");
+      totalCounter.labels.should.include("appName");
+    });
+  });
+
+  Scenario("Failed request should generate metric", () => {
+    let metricsRes;
+    Given("a request is made to an not found endpoint", async () => {
+      metricsRes = await get("/not-found");
+    });
+    When("requesting the /metrics endpoint", async () => {
+      metricsRes = await get("/metrics");
+    });
+    Then("the incoming request error counter should be incremented", () => {
+      const errorCounter = getCounterMetric(metricsRes, "lu_http_incoming_request_errors_total");
+      errorCounter.count.should.eql("1");
+      errorCounter.labels.should.include("404");
+      errorCounter.labels.should.include("appName");
+    });
+  });
+
+  Scenario("Ignored endpoints should not generate metrics", () => {
+    let metricsRes;
+    Given("a request is made to an ignored endpoint", async () => {
+      metricsRes = await get("/_alive");
+    });
+    When("requesting the /metrics endpoint", async () => {
+      metricsRes = await get("/metrics");
+    });
+    Then("the incoming request total counter should not be incremented", () => {
+      const totalCounter = getCounterMetric(metricsRes, "lu_http_incoming_requests_total");
+      expect(totalCounter).to.eql(undefined);
+    });
+  });
+});
+
+function getCounterMetric(metricsRes, metricName) {
+  const metric = metricsRes.text.split("\n").find((row) => row.startsWith(metricName));
+  if (!metric) return;
+  const name = metric.substring(0, metric.indexOf("{"));
+  const labels = metric.substring(metric.indexOf("{"), metric.indexOf("}") + 1);
+  const count = metric.split(" ")[1];
+
+  return {name, labels, count};
+}


### PR DESCRIPTION
Inspirerad av det som gjorts på bang (https://github.com/BonnierNews/bang/blob/master/lib/metrics.js och https://github.com/BonnierNews/bang/blob/master/lib/middleware/requestMetrics.js)

Hittade inga tester där så skrev några sköna som fulparsar responsen i /metrics endpointen.