### PR TITLE
Possible to configure to include namespace and path as label on req metrics

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -2,7 +2,8 @@
   "logging": {
     "log": "file",
     "logLevel": "debug",
-    "logJson": false
+    "logJson": false,
+    "truncateLog": true
   },
   "requestLogging": "file",
   "bugsnagApiKey": null,

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -5,22 +5,22 @@ const client = require("prom-client");
 const httpIncomingRequestsTotal = new client.Counter({
   name: "lu_http_incoming_requests_total",
   help: "Total number of incoming http requests.",
-  labelNames: ["appName"]
+  labelNames: ["appName", "path", "bnNamespace"]
 });
 const httpIncomingRequestsInProgress = new client.Gauge({
   name: "lu_http_incoming_requests_in_progress",
   help: "Number of incoming requests currently processing.",
-  labelNames: ["appName"]
+  labelNames: ["appName", "path", "bnNamespace"]
 });
 const httpIncomingRequestDurationSeconds = new client.Histogram({
   name: "lu_http_incoming_request_duration_seconds",
   help: "Duration of all incoming http requests.",
-  labelNames: ["appName"]
+  labelNames: ["appName", "path", "bnNamespace"]
 });
 const httpIncomingRequestErrorsTotal = new client.Counter({
   name: "lu_http_incoming_request_errors_total",
   help: "Number of incoming requests that responds with error.",
-  labelNames: ["appName", "statusCode"]
+  labelNames: ["appName", "statusCode", "path", "bnNamespace"]
 });
 
 module.exports = {

--- a/lib/request-metrics.js
+++ b/lib/request-metrics.js
@@ -3,6 +3,7 @@
 const metrics = require("./metrics");
 const statusCodeRegex = /^[^2-3]/g;
 const callingAppName = require(`${process.cwd()}/package.json`).name;
+const config = require("exp-config");
 
 module.exports = requestMetrics;
 
@@ -12,21 +13,26 @@ function requestMetrics(req, res, next) {
   if (ignored(req.path)) return next();
 
   const appName = getAppName();
+  const path = getPath(req);
+  const namespace = getNamespace(req);
 
-  const observeRequestDuration = metrics.httpIncomingRequestDurationSeconds.startTimer({appName});
-  metrics.httpIncomingRequestsTotal.inc({appName});
-  metrics.httpIncomingRequestsInProgress.inc({appName});
+  const observeRequestDuration = metrics.httpIncomingRequestDurationSeconds.startTimer({
+    appName,
+    path,
+    bnNamespace: namespace
+  });
+  metrics.httpIncomingRequestsTotal.inc({appName, path, bnNamespace: namespace});
+  metrics.httpIncomingRequestsInProgress.inc({appName, path, bnNamespace: namespace});
 
   let alreadyReported = false;
 
   const report = (requestFailed) => {
     if (alreadyReported) return;
-
-    observeRequestDuration({appName});
-    metrics.httpIncomingRequestsInProgress.dec({appName});
+    observeRequestDuration({appName, path, bnNamespace: namespace});
+    metrics.httpIncomingRequestsInProgress.dec({appName, path, bnNamespace: namespace});
 
     if (requestFailed) {
-      metrics.httpIncomingRequestErrorsTotal.inc({appName, statusCode: res.statusCode});
+      metrics.httpIncomingRequestErrorsTotal.inc({appName, statusCode: res.statusCode, path, bnNamespace: namespace});
     }
 
     alreadyReported = true;
@@ -55,4 +61,21 @@ function ignored(reqPath) {
 
 function getAppName() {
   return callingAppName && callingAppName.replace(/^@[^/]*\//, "").replace(/-/g, "");
+}
+
+function getPath(req) {
+  if (!config.enableReqMetricPathLabel) return "omitted"; // NOTE this should not be enabled if you have params in your routes
+  return req.path;
+}
+
+function getNamespace(req) {
+  if (!config.enableReqMetricNamespaceLabel) return "omitted"; // NOTE this should only be enabled for lu-premium public apis
+  if (req.body && req.body.userId) {
+    const [namespace] = req.body.userId.split("://");
+    return namespace || "omitted";
+  }
+  if (req.body && req.body.namespace) {
+    return req.body.namespace;
+  }
+  return "omitted";
 }

--- a/test/feature/request-metrics-feature.js
+++ b/test/feature/request-metrics-feature.js
@@ -1,10 +1,20 @@
 "use strict";
 
+const config = require("exp-config");
 const expect = require("chai").expect;
 const prometeheus = require("../../lib/prometheus");
-const {get} = require("../helpers/request-helper");
+const {get, post} = require("../helpers/request-helper");
+const router = require("../../lib/routes");
 
 Feature("Incoming request metrics", () => {
+  before(() => {
+    router.get("/epic-endpoint", (req, res) => {
+      return res.status(200).json({});
+    });
+    router.post("/epic-endpoint", (req, res) => {
+      return res.status(200).json({});
+    });
+  });
   // eslint-disable-next-line no-undef
   beforeEachScenario(prometeheus.clear);
 
@@ -31,24 +41,25 @@ Feature("Incoming request metrics", () => {
   Scenario("successfull request should generate metric", () => {
     let metricsRes;
     Given("a request is made to an epic endpoint", async () => {
-      const router = require("../../lib/routes");
-      router.get("/epic-endpoint", (req, res) => {
-        res.sendStatus(200).json({});
-      });
       await get("/epic-endpoint");
     });
     When("requesting the /metrics endpoint", async () => {
       metricsRes = await get("/metrics");
     });
     Then("the incoming request total counter should be incremented", () => {
-      const totalCounter = getCounterMetric(metricsRes, "lu_http_incoming_request_duration_seconds");
+      const totalCounter = getCounterMetric(metricsRes, "lu_http_incoming_requests_total");
       totalCounter.count.should.eql("1");
       totalCounter.labels.should.include("appName");
+      totalCounter.labels.should.include("path");
+      totalCounter.labels.should.include("omitted");
     });
     And("the incoming request duration counter should be incremented", () => {
-      const totalCounter = getCounterMetric(metricsRes, "lu_http_incoming_request_duration_seconds");
-      totalCounter.count.should.eql("1");
-      totalCounter.labels.should.include("appName");
+      const durationCounter = getCounterMetric(metricsRes, "lu_http_incoming_request_duration_seconds");
+      durationCounter.count.should.eql("1");
+      durationCounter.labels.should.include("appName");
+      durationCounter.labels.should.include("path");
+      durationCounter.labels.should.include("omitted");
+      durationCounter.labels.should.include("bnNamespace");
     });
   });
 
@@ -65,8 +76,173 @@ Feature("Incoming request metrics", () => {
       errorCounter.count.should.eql("1");
       errorCounter.labels.should.include("404");
       errorCounter.labels.should.include("appName");
+      errorCounter.labels.should.include("path");
+      errorCounter.labels.should.include("bnNamespace");
     });
   });
+
+  Scenario("successfull request with enableReqMetricPathLabel true should generate metric with path label", () => {
+    before(() => {
+      process.env.ALLOW_TEST_ENV_OVERRIDE = true;
+      config.enableReqMetricPathLabel = true;
+    });
+    after(() => {
+      config.enableReqMetricPathLabel = false;
+      process.env.ALLOW_TEST_ENV_OVERRIDE = false;
+    });
+    let metricsRes;
+    Given("a request is made to an epic endpoint", async () => {
+      await get("/epic-endpoint");
+    });
+    When("requesting the /metrics endpoint", async () => {
+      metricsRes = await get("/metrics");
+    });
+    Then("the incoming request total counter should be incremented", () => {
+      const totalCounter = getCounterMetric(metricsRes, "lu_http_incoming_requests_total");
+      totalCounter.count.should.eql("1");
+      totalCounter.labels.should.include("appName");
+      totalCounter.labels.should.include("path");
+      totalCounter.labels.should.include("/epic-endpoint");
+    });
+    And("the incoming request duration counter should be incremented", () => {
+      const durationCounter = getCounterMetric(metricsRes, "lu_http_incoming_request_duration_seconds");
+      durationCounter.count.should.eql("1");
+      durationCounter.labels.should.include("appName");
+      durationCounter.labels.should.include("path");
+      durationCounter.labels.should.include("/epic-endpoint");
+    });
+  });
+
+  Scenario("Failed request with enableReqMetricPathLabel true should generate metric with path label", () => {
+    before(() => {
+      process.env.ALLOW_TEST_ENV_OVERRIDE = true;
+      config.enableReqMetricPathLabel = true;
+    });
+    after(() => {
+      config.enableReqMetricPathLabel = false;
+      process.env.ALLOW_TEST_ENV_OVERRIDE = false;
+    });
+    let metricsRes;
+    Given("a request is made to an not found endpoint", async () => {
+      metricsRes = await get("/not-found");
+    });
+    When("requesting the /metrics endpoint", async () => {
+      metricsRes = await get("/metrics");
+    });
+    Then("the incoming request error counter should be incremented", () => {
+      const errorCounter = getCounterMetric(metricsRes, "lu_http_incoming_request_errors_total");
+      errorCounter.count.should.eql("1");
+      errorCounter.labels.should.include("404");
+      errorCounter.labels.should.include("appName");
+      errorCounter.labels.should.include("path");
+      errorCounter.labels.should.include("/not-found");
+    });
+  });
+
+  Scenario(
+    "successfull request (with userId) with enableReqMetricNamespaceLabel true should generate metric with bnNamespace label",
+    () => {
+      before(() => {
+        process.env.ALLOW_TEST_ENV_OVERRIDE = true;
+        config.enableReqMetricNamespaceLabel = true;
+      });
+      after(() => {
+        config.enableReqMetricNamespaceLabel = false;
+        process.env.ALLOW_TEST_ENV_OVERRIDE = false;
+      });
+      let metricsRes;
+      Given("a request is made to an epic endpoint with userId", async () => {
+        await post("/epic-endpoint", {userId: "expressen://user-guid"});
+      });
+      When("requesting the /metrics endpoint", async () => {
+        metricsRes = await get("/metrics");
+      });
+      Then("the incoming request total counter should be incremented", () => {
+        const totalCounter = getCounterMetric(metricsRes, "lu_http_incoming_requests_total");
+        totalCounter.count.should.eql("1");
+        totalCounter.labels.should.include("appName");
+        totalCounter.labels.should.include("bnNamespace");
+        totalCounter.labels.should.include("expressen");
+      });
+      And("the incoming request duration counter should be incremented", () => {
+        const durationCounter = getCounterMetric(metricsRes, "lu_http_incoming_request_duration_seconds");
+        durationCounter.count.should.eql("1");
+        durationCounter.labels.should.include("appName");
+        durationCounter.labels.should.include("bnNamespace");
+        durationCounter.labels.should.include("expressen");
+      });
+    }
+  );
+
+  Scenario(
+    "successfull request (with bad userId) with enableReqMetricNamespaceLabel true should generate metric with bnNamespace label",
+    () => {
+      before(() => {
+        process.env.ALLOW_TEST_ENV_OVERRIDE = true;
+        config.enableReqMetricNamespaceLabel = true;
+      });
+      after(() => {
+        config.enableReqMetricNamespaceLabel = false;
+        process.env.ALLOW_TEST_ENV_OVERRIDE = false;
+      });
+      let metricsRes;
+      Given("a request is made to an epic endpoint with userId", async () => {
+        await post("/epic-endpoint", {userId: "user-guid"});
+      });
+      When("requesting the /metrics endpoint", async () => {
+        metricsRes = await get("/metrics");
+      });
+      Then("the incoming request total counter should be incremented", () => {
+        const totalCounter = getCounterMetric(metricsRes, "lu_http_incoming_requests_total");
+        totalCounter.count.should.eql("1");
+        totalCounter.labels.should.include("appName");
+        totalCounter.labels.should.include("bnNamespace");
+        totalCounter.labels.should.include("omitted");
+      });
+      And("the incoming request duration counter should be incremented", () => {
+        const durationCounter = getCounterMetric(metricsRes, "lu_http_incoming_request_duration_seconds");
+        durationCounter.count.should.eql("1");
+        durationCounter.labels.should.include("appName");
+        durationCounter.labels.should.include("bnNamespace");
+        durationCounter.labels.should.include("omitted");
+      });
+    }
+  );
+
+  Scenario(
+    "successfull request (with namespace) with enableReqMetricNamespaceLabel true should generate metric with bnNamespace label",
+    () => {
+      before(() => {
+        process.env.ALLOW_TEST_ENV_OVERRIDE = true;
+        config.enableReqMetricNamespaceLabel = true;
+      });
+      after(() => {
+        config.enableReqMetricNamespaceLabel = false;
+        process.env.ALLOW_TEST_ENV_OVERRIDE = false;
+      });
+      let metricsRes;
+      Given("a request is made to an epic endpoint with userId", async () => {
+        await post("/epic-endpoint", {namespace: "expressen"});
+      });
+      When("requesting the /metrics endpoint", async () => {
+        metricsRes = await get("/metrics");
+      });
+      Then("the incoming request total counter should be incremented", () => {
+        const totalCounter = getCounterMetric(metricsRes, "lu_http_incoming_requests_total");
+        totalCounter.count.should.eql("1");
+        totalCounter.labels.should.include("appName");
+        totalCounter.labels.should.include("bnNamespace");
+        totalCounter.labels.should.include("expressen");
+      });
+      And("the incoming request duration counter should be incremented", () => {
+        const durationCounter = getCounterMetric(metricsRes, "lu_http_incoming_request_duration_seconds");
+        durationCounter.count.should.eql("1");
+        durationCounter.labels.should.include("appName");
+        durationCounter.labels.should.include("bnNamespace");
+        durationCounter.labels.should.include("expressen");
+      });
+    }
+  );
 
   Scenario("Ignored endpoints should not generate metrics", () => {
     let metricsRes;


### PR DESCRIPTION
very specific to the lu-premium "public" apis.
path and bnNamespace label will be registered as "omitted" if not turned on in config with `enableReqMetricPathLabel` and `enableReqMetricNamespaceLabel`