### PR TITLE
Add express route logging

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -16,10 +16,11 @@ function accessLog(req, res, next) {
     res.removeListener("close", afterResponse);
 
     if (!isHealthOrMetricRequest(req)) {
+      const meta = { ...req.debugMeta, ...(req.route && { route: req.route.path, methods: req.route.methods }) };
       if (!res.finished) {
-        logger.info(`"${req.method} ${req.originalUrl}" NO RESPONSE SENT ${new Date() - time} ms`, req.debugMeta);
+        logger.info(`"${req.method} ${req.originalUrl}" NO RESPONSE SENT ${new Date() - time} ms`, meta);
       } else {
-        logger.info(`"${req.method} ${req.originalUrl}" ${res.statusCode} ${new Date() - time} ms`, req.debugMeta);
+        logger.info(`"${req.method} ${req.originalUrl}" ${res.statusCode} ${new Date() - time} ms`, meta);
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lu-server",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lu-server",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "license": "MIT",
       "dependencies": {
         "@bonniernews/gcp-push-metrics": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lu-server",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "engines": {
     "node": ">=18 <=20",
     "yarn": "please use npm"


### PR DESCRIPTION
Log which express route was used when logging requests. Note that `req.route.path` is what's defined in `routes.js` e.g. `"/entity/v2/subscriber/has-one/:type/:id"`, not the full URL that was actually used. This way, we can set up metrics for which routes are used, and by which service accounts.