### PR TITLE
Add logging of request inputs

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -8,8 +8,20 @@ const isHealthOrMetricRequest = require("./is-health-or-metric-request");
 const requestMetrics = require("./request-metrics");
 const statusShutdown = require("./status-middleware-when-shutting-down");
 
+function hasData(obj) {
+  return Object.keys(obj).length;
+}
+
 function accessLog(req, res, next) {
   const time = new Date();
+
+  if (!isHealthOrMetricRequest(req)) {
+    const usefulStuff = [];
+    if (hasData(req.body)) usefulStuff.push(`body: ${JSON.stringify(req.body)}`);
+    if (hasData(req.query)) usefulStuff.push(`query: ${JSON.stringify(req.query)}`);
+    const inputs = usefulStuff.length ? ` with ${usefulStuff.join(", ")}` : "";
+    logger.info(`${req.method} received on ${req.url}${inputs}`);
+  }
 
   function afterResponse() {
     res.removeListener("finish", afterResponse);

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -9,7 +9,7 @@ const requestMetrics = require("./request-metrics");
 const statusShutdown = require("./status-middleware-when-shutting-down");
 
 function hasData(obj) {
-  return Object.keys(obj).length;
+  return obj && Object.keys(obj).length;
 }
 
 function accessLog(req, res, next) {


### PR DESCRIPTION
Sometimes (like really, really often) it would be very nice to see what we actually received as a payload.

This does that.
